### PR TITLE
Add better invalid token handling

### DIFF
--- a/classes/EventListener/LoadDataContainerListener.php
+++ b/classes/EventListener/LoadDataContainerListener.php
@@ -160,6 +160,15 @@ class LoadDataContainerListener
                     'sql'        => "int(10) unsigned NOT NULL default 0",
                     'relation'   => ['type' => 'hasOne', 'load' => 'lazy']
                 ],
+                'huhSubOptInTokenInvalidJumpTo'       => [
+                    'label'     => &$GLOBALS['TL_LANG'][$table]['huhSubOptInTokenInvalidJumpTo'],
+                    'exclude'    => true,
+                    'inputType'  => 'pageTree',
+                    'foreignKey' => 'tl_page.title',
+                    'eval'       => ['fieldType' => 'radio', 'tl_class' => 'clr'],
+                    'sql'        => "int(10) unsigned NOT NULL default 0",
+                    'relation'   => ['type' => 'hasOne', 'load' => 'lazy']
+                ],
                 'huhSubOptInField'        => [
                     'label'     => &$GLOBALS['TL_LANG'][$table]['huhSubOptInField'],
                     'inputType'        => 'select',
@@ -183,7 +192,7 @@ class LoadDataContainerListener
                     $dca['subpalettes']['storeAsSubmission']
                 );
                 $dca['palettes']['__selector__'][]       = 'huhSubAddOptIn';
-                $dca['subpalettes']['huhSubAddOptIn']    = 'huhSubOptInNotification,huhSubOptInJumpTo,huhSubOptInField';
+                $dca['subpalettes']['huhSubAddOptIn']    = 'huhSubOptInNotification,huhSubOptInJumpTo,huhSubOptInField,huhSubOptInTokenInvalid';
             }
 
             $dca['fields'] = array_merge($dca['fields'], $fields);

--- a/classes/EventListener/LoadDataContainerListener.php
+++ b/classes/EventListener/LoadDataContainerListener.php
@@ -192,7 +192,7 @@ class LoadDataContainerListener
                     $dca['subpalettes']['storeAsSubmission']
                 );
                 $dca['palettes']['__selector__'][]       = 'huhSubAddOptIn';
-                $dca['subpalettes']['huhSubAddOptIn']    = 'huhSubOptInNotification,huhSubOptInJumpTo,huhSubOptInField,huhSubOptInTokenInvalid';
+                $dca['subpalettes']['huhSubAddOptIn']    = 'huhSubOptInNotification,huhSubOptInJumpTo,huhSubOptInField,huhSubOptInTokenInvalidJumpTo';
             }
 
             $dca['fields'] = array_merge($dca['fields'], $fields);

--- a/config/config.php
+++ b/config/config.php
@@ -156,12 +156,12 @@ $GLOBALS['TL_MODELS']['tl_submission_archive'] = '\HeimrichHannot\Submissions\Su
  * Hooks
  */
 $GLOBALS['TL_HOOKS']['loadDataContainer']['submissions_setPTableForDelete'] = ['HeimrichHannot\Submissions\Backend\SubmissionArchiveBackend', 'setPTableForDelete'];
-$GLOBALS['TL_HOOKS']['loadDataContainer']['huh_submissions']                = [\HeimrichHannot\Submissions\EventListener\LoadDataContainerListener::class, 'onLoadDataContainer'];
-$GLOBALS['TL_HOOKS']['prepareFormData']['huh_submissions']         = [\HeimrichHannot\Submissions\EventListener\FormGeneratorListener::class, 'onPrepareFormData'];
-$GLOBALS['TL_HOOKS']['storeFormData']['huh_submissions']           = [\HeimrichHannot\Submissions\EventListener\FormGeneratorListener::class, 'onStoreFormData'];
-$GLOBALS['TL_HOOKS']['processFormData']['huh_submissions']         = [\HeimrichHannot\Submissions\EventListener\FormGeneratorListener::class, 'onProcessFormData'];
+$GLOBALS['TL_HOOKS']['loadDataContainer']['huh_submissions'] = [\HeimrichHannot\Submissions\EventListener\LoadDataContainerListener::class, 'onLoadDataContainer'];
+$GLOBALS['TL_HOOKS']['prepareFormData']['huh_submissions'] = [\HeimrichHannot\Submissions\EventListener\FormGeneratorListener::class, 'onPrepareFormData'];
+$GLOBALS['TL_HOOKS']['storeFormData']['huh_submissions'] = [\HeimrichHannot\Submissions\EventListener\FormGeneratorListener::class, 'onStoreFormData'];
+$GLOBALS['TL_HOOKS']['processFormData']['huh_submissions'] = [\HeimrichHannot\Submissions\EventListener\FormGeneratorListener::class, 'onProcessFormData'];
 $GLOBALS['TL_HOOKS']['sendNotificationMessage']['huh_submissions'] = [\HeimrichHannot\Submissions\EventListener\FormGeneratorListener::class, 'onSendNotificationMessage'];
-$GLOBALS['TL_HOOKS']['initializeSystem']['huh_submissions'] = [\HeimrichHannot\Submissions\EventListener\InitializeSystemListener::class, '__invoke'];
+$GLOBALS['TL_HOOKS']['getPageLayout']['huh_submissions'] = [\HeimrichHannot\Submissions\EventListener\GeneratePageListener::class, '__invoke'];
 
 /**
  * Add permissions

--- a/languages/de/tl_form.php
+++ b/languages/de/tl_form.php
@@ -8,6 +8,6 @@ $lang['submissionArchive'] = ['Einsendungsarchiv', "Das Einsendungsarchiv, in we
 $lang['huhSubAddOptIn'] = ['Opt-in aktivieren', "Soll für dieses Formular ein Opt-in verwendet werden?"];
 $lang['huhSubOptInNotification'] = ['Opt-in Benachrichtigung', "Wählen Sie hier die Opt-in-Benachrichtigung aus."];
 $lang['huhSubOptInJumpTo'] = ['Opt-in Weiterleitungsseite', "Wählen Sie die Seite aus, auf welche nach erfolgreichem Opt-in weitergeleitet werden soll."];
-$lang['huhSubOptInTokenInvalidJumpTo'] = ['"Token-Bestätig"-Weiterleitungsseite', "Wählen Sie die Seite aus, auf welche weitergeleitet werden soll, wenn der Token bereits bestätigt wurde."];
+$lang['huhSubOptInTokenInvalidJumpTo'] = ['"Token bereits bestätigt"-Weiterleitungsseite', "Wählen Sie die Seite aus, auf welche weitergeleitet werden soll, wenn der Token bereits bestätigt wurde."];
 $lang['huhSubOptInField'] = ['Opt-in Bestätigungsfeld', "Wählen Sie hier ein Feld aus, welches bei erfolgreichem Opt-in auf true gesetzt werden soll."];
 

--- a/languages/de/tl_form.php
+++ b/languages/de/tl_form.php
@@ -8,5 +8,6 @@ $lang['submissionArchive'] = ['Einsendungsarchiv', "Das Einsendungsarchiv, in we
 $lang['huhSubAddOptIn'] = ['Opt-in aktivieren', "Soll für dieses Formular ein Opt-in verwendet werden?"];
 $lang['huhSubOptInNotification'] = ['Opt-in Benachrichtigung', "Wählen Sie hier die Opt-in-Benachrichtigung aus."];
 $lang['huhSubOptInJumpTo'] = ['Opt-in Weiterleitungsseite', "Wählen Sie die Seite aus, auf welche nach erfolgreichem Opt-in weitergeleitet werden soll."];
+$lang['huhSubOptInTokenInvalidJumpTo'] = ['"Invalider Token"-Weiterleitungsseite', "Wählen Sie die Seite aus, auf welche weitergeleitet werden soll, wenn der Token abgelaufen ist, bereits bestätigt wurde oder nicht existiert."];
 $lang['huhSubOptInField'] = ['Opt-in Bestätigungsfeld', "Wählen Sie hier ein Feld aus, welches bei erfolgreichem Opt-in auf true gesetzt werden soll."];
 

--- a/languages/de/tl_form.php
+++ b/languages/de/tl_form.php
@@ -8,6 +8,6 @@ $lang['submissionArchive'] = ['Einsendungsarchiv', "Das Einsendungsarchiv, in we
 $lang['huhSubAddOptIn'] = ['Opt-in aktivieren', "Soll für dieses Formular ein Opt-in verwendet werden?"];
 $lang['huhSubOptInNotification'] = ['Opt-in Benachrichtigung', "Wählen Sie hier die Opt-in-Benachrichtigung aus."];
 $lang['huhSubOptInJumpTo'] = ['Opt-in Weiterleitungsseite', "Wählen Sie die Seite aus, auf welche nach erfolgreichem Opt-in weitergeleitet werden soll."];
-$lang['huhSubOptInTokenInvalidJumpTo'] = ['"Invalider Token"-Weiterleitungsseite', "Wählen Sie die Seite aus, auf welche weitergeleitet werden soll, wenn der Token abgelaufen ist, bereits bestätigt wurde oder nicht existiert."];
+$lang['huhSubOptInTokenInvalidJumpTo'] = ['"Token-Bestätig"-Weiterleitungsseite', "Wählen Sie die Seite aus, auf welche weitergeleitet werden soll, wenn der Token bereits bestätigt wurde."];
 $lang['huhSubOptInField'] = ['Opt-in Bestätigungsfeld', "Wählen Sie hier ein Feld aus, welches bei erfolgreichem Opt-in auf true gesetzt werden soll."];
 

--- a/languages/en/tl_form.php
+++ b/languages/en/tl_form.php
@@ -7,6 +7,7 @@ $lang['submissionArchive'] = ['Submission archive', "The submissin archive which
 
 $lang['huhSubAddOptIn']          = ['Activate opt-in', "Activate opt-in process for form submissions."];
 $lang['huhSubOptInNotification'] = ['Opt-in notification', "Choose an opt-in notification."];
-$lang['huhSubOptInJumpTo']       = ['Opt-in Weiterleitungsseite', "Choose a page to which the visitor will be redirected after successful opt-in."];
+$lang['huhSubOptInJumpTo']       = ['Opt-in redirect page', "Choose a page to which the visitor will be redirected after successful opt-in."];
+$lang['huhSubOptInTokenInvalidJumpTo'] = ['Invalid token redirect page', "Choose a page the visitor will be redirected to if te token is expired, already confirmed or not existing."];
 $lang['huhSubOptInField']        = ['Opt-in confirmation field', "Choose a field that should set to true after a successful opt-in."];
 

--- a/languages/en/tl_form.php
+++ b/languages/en/tl_form.php
@@ -8,6 +8,6 @@ $lang['submissionArchive'] = ['Submission archive', "The submissin archive which
 $lang['huhSubAddOptIn']          = ['Activate opt-in', "Activate opt-in process for form submissions."];
 $lang['huhSubOptInNotification'] = ['Opt-in notification', "Choose an opt-in notification."];
 $lang['huhSubOptInJumpTo']       = ['Opt-in redirect page', "Choose a page to which the visitor will be redirected after successful opt-in."];
-$lang['huhSubOptInTokenInvalidJumpTo'] = ['Invalid token redirect page', "Choose a page the visitor will be redirected to if te token is expired, already confirmed or not existing."];
+$lang['huhSubOptInTokenInvalidJumpTo'] = ['Token confirmed page', "Choose a page the visitor will be redirected to if the token is already confirmed."];
 $lang['huhSubOptInField']        = ['Opt-in confirmation field', "Choose a field that should set to true after a successful opt-in."];
 


### PR DESCRIPTION

This PR enhances the invalid token expirience. It is not possible to set a redirect page, if the token is confirmed. If the token is invalid in another way or no redirect page is set, there is now a redirect to a 404 instead of throwing an exception.﻿
